### PR TITLE
Bump powermock-api-mockito2 from 1.7.4 to 2.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,7 +307,7 @@ dependencies {
     testCompile "com.github.tomakehurst:wiremock:2.19.0"
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.21.0'
     testCompile group: 'org.mockito', name: 'mockito-inline', version: '3.1.0'
-    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '1.7.4'
+    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.4'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
     testCompile group: 'org.pitest', name: 'pitest', version: versions.pitest


### PR DESCRIPTION

### JIRA link (if applicable) ###
NA


### Change description ###
Bump powermock-api-mockito2 from 1.7.4 to 2.0.4


**Does this PR introduce a breaking change?** (check one with "x")
No
