### PR TITLE
Rdcc_1873_1:get the email from header instead of query param for email masking

### DIFF
--- a/charts/rd-user-profile-api/values.preview.template.yaml
+++ b/charts/rd-user-profile-api/values.preview.template.yaml
@@ -16,6 +16,5 @@ java:
     rd:
       secrets:
         - s2s-secret
-        - AppInsightsInstrumentationKey
 
 

--- a/charts/rd-user-profile-api/values.preview.template.yaml
+++ b/charts/rd-user-profile-api/values.preview.template.yaml
@@ -16,5 +16,6 @@ java:
     rd:
       secrets:
         - s2s-secret
+        - AppInsightsInstrumentationKey
 
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/RetrieveUserProfileFuncTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/RetrieveUserProfileFuncTest.java
@@ -97,7 +97,7 @@ public class RetrieveUserProfileFuncTest extends AbstractFunctional {
 
         UserProfileResponse resource =
                 testRequestHandler.getEmailFromHeader(
-                        requestUri + "?email=" + userProfileCreationData.getEmail().toLowerCase(),
+                        requestUri + "?email=" + " ",
                         UserProfileResponse.class,
                         userProfileCreationData.getEmail().toLowerCase()
                 );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/RetrieveUserProfileFuncTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/RetrieveUserProfileFuncTest.java
@@ -90,6 +90,23 @@ public class RetrieveUserProfileFuncTest extends AbstractFunctional {
     }
 
     @Test
+    public void should_get_user_profile_by_email_from_header() throws Exception {
+
+        UserProfileCreationData userProfileCreationData = createUserProfileData();
+        UserProfileCreationResponse createdResource = createUserProfile(userProfileCreationData, HttpStatus.CREATED);
+
+        UserProfileResponse resource =
+                testRequestHandler.getEmailFromHeader(
+                        requestUri + "?email=" + userProfileCreationData.getEmail().toLowerCase(),
+                        UserProfileResponse.class,
+                        userProfileCreationData.getEmail().toLowerCase()
+                );
+
+        verifyGetUserProfile(resource, userProfileCreationData);
+        assertThat(createdResource.getIdamId()).isNotNull();
+    }
+
+    @Test
     public void should_return_400_when_required_email_field_is_missing() {
         String json = "{\"firstName\":\"iWvKhGLXCiOMMbZtngbR\",\"lastName\":\"mXlpNLcbodhABAWKCKbj\"}";
         testRequestHandler.sendPost(json, HttpStatus.BAD_REQUEST, requestUri);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/RetrieveUserProfileFuncTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/RetrieveUserProfileFuncTest.java
@@ -97,7 +97,7 @@ public class RetrieveUserProfileFuncTest extends AbstractFunctional {
 
         UserProfileResponse resource =
                 testRequestHandler.getEmailFromHeader(
-                        requestUri + "?email=" + " ",
+                        requestUri + "?email=" + "up@prdfunctestuser.com",
                         UserProfileResponse.class,
                         userProfileCreationData.getEmail().toLowerCase()
                 );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/client/FuncTestRequestHandler.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/client/FuncTestRequestHandler.java
@@ -126,12 +126,38 @@ public class FuncTestRequestHandler {
         log.info("S2S Token : {}, Bearer Token : {}", s2sToken, bearerToken);
 
         return SerenityRest
+                .given()
+                //.headers(authorizationHeadersProvider.getServiceAuthorization())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .baseUri(baseUrl)
+                .header("ServiceAuthorization", BEARER + s2sToken)
+                .header("Authorization", BEARER + bearerToken)
+                .when()
+                .get(urlPath)
+                .then()
+                .log().all(true)
+                .statusCode(httpStatus.value()).extract().response();
+    }
+
+    public <T> T getEmailFromHeader(String urlPath, Class<T> clazz, String email) {
+        return getEmailFromHeader(HttpStatus.OK, urlPath, email).as(clazz);
+    }
+
+
+    public Response getEmailFromHeader(HttpStatus httpStatus, String urlPath, String email) {
+        String s2sToken = getS2sToken();
+        String bearerToken = getBearerToken();
+
+        log.info("S2S Token : {}, Bearer Token : {}", s2sToken, bearerToken);
+
+        return SerenityRest
             .given()
             //.headers(authorizationHeadersProvider.getServiceAuthorization())
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .baseUri(baseUrl)
             .header("ServiceAuthorization", BEARER + s2sToken)
             .header("Authorization", BEARER + bearerToken)
+            .header("USER-EMAIL",  email)
             .when()
             .get(urlPath)
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/client/FuncTestRequestHandler.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/client/FuncTestRequestHandler.java
@@ -127,7 +127,6 @@ public class FuncTestRequestHandler {
 
         return SerenityRest
                 .given()
-                //.headers(authorizationHeadersProvider.getServiceAuthorization())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .baseUri(baseUrl)
                 .header("ServiceAuthorization", BEARER + s2sToken)
@@ -152,12 +151,11 @@ public class FuncTestRequestHandler {
 
         return SerenityRest
             .given()
-            //.headers(authorizationHeadersProvider.getServiceAuthorization())
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .baseUri(baseUrl)
             .header("ServiceAuthorization", BEARER + s2sToken)
             .header("Authorization", BEARER + bearerToken)
-            .header("USER-EMAIL",  email)
+            .header("User-Email",  email)
             .when()
             .get(urlPath)
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/client/FuncTestRequestHandler.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/userprofileapi/client/FuncTestRequestHandler.java
@@ -155,7 +155,7 @@ public class FuncTestRequestHandler {
             .baseUri(baseUrl)
             .header("ServiceAuthorization", BEARER + s2sToken)
             .header("Authorization", BEARER + bearerToken)
-            .header("User-Email",  email)
+            .header("UserEmail",  email)
             .when()
             .get(urlPath)
             .then()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/client/UserProfileRequestHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/client/UserProfileRequestHandlerTest.java
@@ -90,6 +90,31 @@ public class UserProfileRequestHandlerTest {
         return objectMapper.readValue(result.getResponse().getContentAsString(), clazz);
     }
 
+    public <T> T sendGetFromHeader(MockMvc mockMvc,
+                         String path,
+                         HttpStatus expectedHttpStatus,
+                         Class<T> clazz, String email) throws Exception {
+
+        MvcResult result = sendGetFromHeader(mockMvc, path, expectedHttpStatus, email);
+        assertThat(result.getResponse().getContentAsString())
+                .as("Expected json content was empty")
+                .isNotEmpty();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), clazz);
+    }
+
+    public MvcResult sendGetFromHeader(MockMvc mockMvc,
+                                       String path,
+                                       HttpStatus expectedHttpStatus, String email) throws Exception {
+        HttpHeaders httpHeaders = getMultipleAuthHeaders();
+        httpHeaders.add("User-Email", email);
+        return mockMvc.perform(get(path)
+                .headers(httpHeaders)
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().is(expectedHttpStatus.value()))
+                .andReturn();
+    }
+
     public <T> T sendPut(MockMvc mockMvc,
                          String path,
                          Object body,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/client/UserProfileRequestHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/client/UserProfileRequestHandlerTest.java
@@ -107,7 +107,7 @@ public class UserProfileRequestHandlerTest {
                                        String path,
                                        HttpStatus expectedHttpStatus, String email) throws Exception {
         HttpHeaders httpHeaders = getMultipleAuthHeaders();
-        httpHeaders.add("User-Email", email);
+        httpHeaders.add("UserEmail", email);
         return mockMvc.perform(get(path)
                 .headers(httpHeaders)
                 .contentType(APPLICATION_JSON))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/integration/RetrieveUserProfileIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/integration/RetrieveUserProfileIntTest.java
@@ -155,6 +155,40 @@ public class RetrieveUserProfileIntTest extends AuthorizationEnabledIntegrationT
     }
 
     @Test
+    public void should_retrieve_user_profile_resource_with_roles_by_email_fromHeader() throws Exception {
+        UserProfile userProfile = userProfileMap.get("user");
+
+        UserProfileWithRolesResponse retrievedResource =
+                userProfileRequestHandlerTest.sendGetFromHeader(
+                        mockMvc,
+                        APP_BASE_PATH + SLASH + "roles" + "?" + "email=" + "up@prdfunctestuser.com",
+                        OK,
+                        UserProfileWithRolesResponse.class,
+                        userProfile.getEmail()
+                );
+
+        assertThat(retrievedResource).isNotNull();
+        assertThat(retrievedResource.getRoles().size()).isGreaterThan(0);
+
+        Optional<UserProfile> optionalUserProfile = userProfileRepository.findByIdamId(retrievedResource.getIdamId());
+        UserProfile persistedUserProfile = optionalUserProfile.get();
+
+        List<Audit> matchedAuditRecords = getMatchedAuditRecords(auditRepository.findAll(),
+                persistedUserProfile.getIdamId());
+        assertThat(matchedAuditRecords.size()).isEqualTo(1);
+        Audit audit = matchedAuditRecords.get(0);
+
+        assertThat(audit).isNotNull();
+        assertThat(audit.getIdamRegistrationResponse()).isEqualTo(200);
+        assertThat(audit.getStatusMessage()).isEqualTo(IdamStatusResolver.OK);
+        assertThat(audit.getSource()).isEqualTo(ResponseSource.API);
+        assertThat(audit.getUserProfile().getIdamId()).isEqualTo(retrievedResource.getIdamId());
+        assertThat(audit.getAuditTs()).isNotNull();
+
+    }
+
+
+    @Test
     public void should_retrieve_user_profile_resource_with_email() throws Exception {
         UserProfile userProfile = userProfileMap.get("user");
 
@@ -164,6 +198,40 @@ public class RetrieveUserProfileIntTest extends AuthorizationEnabledIntegrationT
                         APP_BASE_PATH + "?" + "email=" + userProfile.getEmail(),
                         OK,
                         UserProfileResponse.class
+                );
+
+        assertThat(retrievedResource).isNotNull();
+
+    }
+
+    @Test
+    public void should_retrieve_user_profile_resource_with_email_from_header() throws Exception {
+        UserProfile userProfile = userProfileMap.get("user");
+
+        UserProfileResponse retrievedResource =
+                userProfileRequestHandlerTest.sendGetFromHeader(
+                        mockMvc,
+                        APP_BASE_PATH + "?" + "email=" + userProfile.getEmail(),
+                        OK,
+                        UserProfileResponse.class,
+                        userProfile.getEmail()
+                );
+
+        assertThat(retrievedResource).isNotNull();
+
+    }
+
+    @Test
+    public void should_not_retrieve_user_profile_resource_with_unknown_email_from_header() throws Exception {
+        UserProfile userProfile = userProfileMap.get("user");
+
+        UserProfileResponse retrievedResource =
+                userProfileRequestHandlerTest.sendGetFromHeader(
+                        mockMvc,
+                        APP_BASE_PATH + "?" + "email=" + userProfile.getEmail(),
+                        NOT_FOUND,
+                        UserProfileResponse.class,
+                        "up@prdfunctestuser.com"
                 );
 
         assertThat(retrievedResource).isNotNull();
@@ -251,6 +319,20 @@ public class RetrieveUserProfileIntTest extends AuthorizationEnabledIntegrationT
 
     }
 
+    @Test
+    public void should_return_404_when_query_by_email_is_empty_and_header_isEmpty() throws Exception {
+        MvcResult result =
+                userProfileRequestHandlerTest.sendGetFromHeader(
+                        mockMvc,
+                        APP_BASE_PATH + "?email=",
+                        NOT_FOUND,
+                        ""
+                );
+
+        assertThat(result.getResponse()).isNotNull();
+        assertThat(result.getResponse().getContentAsString()).isNotEmpty();
+
+    }
 
     @Test
     public void should_return_404_when_query_by_userId_is_empty() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/integration/RetrieveUserProfileInternalServerErrorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/integration/RetrieveUserProfileInternalServerErrorIntTest.java
@@ -106,6 +106,17 @@ public class RetrieveUserProfileInternalServerErrorIntTest extends Authorization
     }
 
     @Test
+    public void should_return_500_when_email_from_header_and_repository_throws_an_unknown_exception() throws Exception {
+        when(userProfileRepository.findByEmail(anyString()))
+                .thenThrow(new RuntimeException("This is a test exception"));
+
+        MvcResult result = userProfileRequestHandlerTest.sendGetFromHeader(mockMvc, APP_BASE_PATH + "?email="
+                .concat("randomemail@somewhere.com"), INTERNAL_SERVER_ERROR,"randomemail@somewhere.com");
+
+        assertThat(result.getResponse().getContentAsString()).isNotEmpty();
+    }
+
+    @Test
     public void should_return_500_when_query_by_userId_and_repository_throws_an_unknown_exception() throws Exception {
         when(userProfileRepository.findByIdamId(any(String.class)))
                 .thenThrow(new RuntimeException("This is a test exception"));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/integration/RetrieveUserProfileWithIdamErrorsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/userprofileapi/integration/RetrieveUserProfileWithIdamErrorsIntTest.java
@@ -104,6 +104,30 @@ public class RetrieveUserProfileWithIdamErrorsIntTest extends AuthorizationEnabl
     }
 
     @Test
+    public void shouldFailWhenIdamReturnsUnSuccessfullResponseResourceWithRolesByEmailFromHeader() throws Exception {
+        UserProfile userProfile = userProfileMap.get("user");
+        MvcResult result =
+                userProfileRequestHandlerTest.sendGetFromHeader(
+                        mockMvc,
+                        APP_BASE_PATH + SLASH + "roles" + "?" + "email=" + userProfile.getEmail(),
+                        NOT_FOUND,
+                        userProfile.getEmail()
+                );
+
+        List<Audit> matchedAuditRecords = getMatchedAuditRecords(auditRepository.findAll(), userProfile.getIdamId());
+        assertThat(matchedAuditRecords.size()).isEqualTo(1);
+        Audit audit = matchedAuditRecords.get(0);
+
+        assertThat(audit).isNotNull();
+        assertThat(audit.getIdamRegistrationResponse()).isEqualTo(404);
+        assertThat(audit.getStatusMessage()).isEqualTo(IdamStatusResolver.NOT_FOUND);
+        assertThat(audit.getSource()).isEqualTo(ResponseSource.API);
+        assertThat(audit.getUserProfile().getIdamId()).isNotNull();
+        assertThat(audit.getAuditTs()).isNotNull();
+
+    }
+
+    @Test
     public void should_see_idam_error_message_when_idam_returns_404_response_with_roles_by_id() throws Exception {
 
         mockWithGetFail(NOT_FOUND, true);

--- a/src/main/java/uk/gov/hmcts/reform/userprofileapi/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/userprofileapi/config/SwaggerConfiguration.java
@@ -35,7 +35,8 @@ public class SwaggerConfiguration {
         return
             newArrayList(
                     new ApiKey("Authorization", "Authorization","header"),
-                    new ApiKey("ServiceAuthorization", "ServiceAuthorization", "header")
+                    new ApiKey("ServiceAuthorization", "ServiceAuthorization", "header"),
+                    new ApiKey("User-Email", "User-Email", "header")
             );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/userprofileapi/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/userprofileapi/config/SwaggerConfiguration.java
@@ -36,7 +36,7 @@ public class SwaggerConfiguration {
             newArrayList(
                     new ApiKey("Authorization", "Authorization","header"),
                     new ApiKey("ServiceAuthorization", "ServiceAuthorization", "header"),
-                    new ApiKey("User-Email", "User-Email", "header")
+                    new ApiKey("UserEmail", "UserEmail", "header")
             );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileController.java
+++ b/src/main/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileController.java
@@ -476,7 +476,7 @@ public class UserProfileController {
                 ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes());
         if (nonNull(servletRequestAttributes)) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
-            userEmail = request.getHeader("UserEmaill") != null ? request.getHeader("UserEmail") : email;
+            userEmail = request.getHeader("UserEmail") != null ? request.getHeader("UserEmail") : email;
         }
         return userEmail;
     }

--- a/src/main/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileController.java
+++ b/src/main/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileController.java
@@ -185,7 +185,7 @@ public class UserProfileController {
             authorizations = {
                     @Authorization(value = "ServiceAuthorization"),
                     @Authorization(value = "Authorization"),
-                    @Authorization(value = "User-Email")
+                    @Authorization(value = "UserEmail")
             }
     )
 
@@ -236,7 +236,7 @@ public class UserProfileController {
             authorizations = {
                     @Authorization(value = "ServiceAuthorization"),
                     @Authorization(value = "Authorization"),
-                    @Authorization(value = "User-Email")
+                    @Authorization(value = "UserEmail")
             })
     @ApiResponses({
             @ApiResponse(
@@ -476,7 +476,7 @@ public class UserProfileController {
                 ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes());
         if (nonNull(servletRequestAttributes)) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
-            userEmail = request.getHeader("User-Email") != null ? request.getHeader("User-Email") : email;
+            userEmail = request.getHeader("UserEmaill") != null ? request.getHeader("UserEmail") : email;
         }
         return userEmail;
     }

--- a/src/main/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileController.java
+++ b/src/main/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileController.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.userprofileapi.controller;
 
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.userprofileapi.util.UserProfileValidator.isUserIdValid;
@@ -13,6 +14,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import uk.gov.hmcts.reform.userprofileapi.controller.request.UserProfileDataRequest;
 import uk.gov.hmcts.reform.userprofileapi.controller.response.AttributeResponse;
 import uk.gov.hmcts.reform.userprofileapi.controller.response.UserProfileCreationResponse;
@@ -180,7 +184,8 @@ public class UserProfileController {
     @ApiOperation(value = "Retrieves a User Profile and their Roles with the given Email Address",
             authorizations = {
                     @Authorization(value = "ServiceAuthorization"),
-                    @Authorization(value = "Authorization")
+                    @Authorization(value = "Authorization"),
+                    @Authorization(value = "User-Email")
             }
     )
 
@@ -218,19 +223,20 @@ public class UserProfileController {
     )
     @ResponseBody
     public ResponseEntity<UserProfileWithRolesResponse> getUserProfileWithRolesByEmail(@RequestParam(value = "email",
-            required = true) String email) {
-        //Getting user profile by email
-
-        requireNonNull(email, "email cannot be null");
+            required = false) String email) {
+        //Getting user profile by email from header or request param
+        String userEmail = getUserEmail(email);
+        requireNonNull(userEmail, "email cannot be null");
         UserProfileWithRolesResponse response = userProfileService
-                .retrieveWithRoles(new UserProfileIdentifier(IdentifierName.EMAIL, email.toLowerCase()));
+                .retrieveWithRoles(new UserProfileIdentifier(IdentifierName.EMAIL, userEmail.toLowerCase()));
         return ResponseEntity.ok(response);
     }
 
     @ApiOperation(value = "Retrieve a User Profile by Email or ID. If both are present then Email is used to retrieve.",
             authorizations = {
                     @Authorization(value = "ServiceAuthorization"),
-                    @Authorization(value = "Authorization")
+                    @Authorization(value = "Authorization"),
+                    @Authorization(value = "User-Email")
             })
     @ApiResponses({
             @ApiResponse(
@@ -266,19 +272,19 @@ public class UserProfileController {
     @ResponseBody
     public ResponseEntity<UserProfileResponse> getUserProfileByEmail(@RequestParam(value = "email",
                                                                                  required = false) String email,
-                                                                     @ApiParam(name = "userId", required = false)
                                                                      @RequestParam(value = "userId", required = false)
                                                                              String userId) {
         UserProfileResponse response;
-        if (email == null && userId == null) {
+        String userEmail = getUserEmail(email);
+        if (userEmail == null && userId == null) {
             return ResponseEntity.badRequest().build();
-        } else if (email != null) {
+        } else if (userEmail != null) {
 
             //Getting user profile by email
 
             response =
                     userProfileService.retrieve(
-                            new UserProfileIdentifier(IdentifierName.EMAIL, email.toLowerCase().trim())
+                            new UserProfileIdentifier(IdentifierName.EMAIL, userEmail.toLowerCase().trim())
                     );
         } else {
             isUserIdValid(userId, true);
@@ -457,12 +463,22 @@ public class UserProfileController {
     @ResponseBody
     public ResponseEntity<UserProfilesDeletionResponse> deleteUserProfiles(@Valid @RequestBody UserProfileDataRequest
                                                                                        userProfilesDeletionDataReq) {
-
         UserProfilesDeletionResponse resource = null;
         validateUserIds(userProfilesDeletionDataReq);
         resource = userProfileService.delete(userProfilesDeletionDataReq);
         return ResponseEntity.status(resource.getStatusCode()).body(resource);
 
+    }
+
+    private  String getUserEmail(String email) {
+        String userEmail = null;
+        ServletRequestAttributes servletRequestAttributes =
+                ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes());
+        if (nonNull(servletRequestAttributes)) {
+            HttpServletRequest request = servletRequestAttributes.getRequest();
+            userEmail = request.getHeader("User-Email") != null ? request.getHeader("User-Email") : email;
+        }
+        return userEmail;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/userprofileapi/controller/UserProfileControllerTest.java
@@ -159,7 +159,6 @@ public class UserProfileControllerTest {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
         UserProfileWithRolesResponse responseMock = Mockito.mock(UserProfileWithRolesResponse.class);
         when(httpRequest.getHeader(anyString())).thenReturn("test@test.com");
-        //when(jsonFeignResponseHelperMock.getUserEmail(any())).thenReturn("test@test.com");
         when(userProfileServiceMock.retrieveWithRoles(any(UserProfileIdentifier.class))).thenReturn(responseMock);
         String email = " ";
         assertThat(sut.getUserProfileWithRolesByEmail(email)).isEqualTo(ResponseEntity.ok(responseMock));


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-1873

### Change description ###

feat:get the email from header instead of query param for email masking

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
