### PR TITLE
build: Upgraded httpclient and hibernate-core versions to fix CVE-2020-13956 and CVE-2020-25638

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,8 +306,6 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-oauth2-client"
     compile "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     compile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.20'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    compile group: 'org.hibernate', name: 'hibernate-core', version: '5.4.24.Final'
     implementation "io.github.openfeign:feign-httpclient:11.0"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -322,6 +320,17 @@ dependencies {
     compile (group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0') {
         exclude group: "com.sun.xml.bind", module: "jaxb-osgi"
         exclude group: "org.apache.sling"
+    }
+    implementation('org.apache.httpcomponents:httpclient:4.5.13') {
+        because 'Apache HttpClient versions prior to version 4.5.13 can misinterpret malformed authority component in ' +
+                'request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.'
+    }
+    implementation('org.hibernate:hibernate-core:5.4.24.Final') {
+        because 'A flaw was found in hibernate-core in versions prior to and including 5.4.23.Final. ' +
+                'A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a ' +
+                'literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized ' +
+                'information or possibly conduct further attacks. The highest threat from this vulnerability is to data ' +
+                'confidentiality and integrity.'
     }
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,8 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-oauth2-client"
     compile "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     compile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.20'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+    compile group: 'org.hibernate', name: 'hibernate-core', version: '5.4.24.Final'
     implementation "io.github.openfeign:feign-httpclient:11.0"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/build.gradle
+++ b/build.gradle
@@ -332,6 +332,18 @@ dependencies {
                 'information or possibly conduct further attacks. The highest threat from this vulnerability is to data ' +
                 'confidentiality and integrity.'
     }
+    implementation('org.apache.tomcat.embed:tomcat-embed-core:9.0.40') {
+        because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
+                'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
+                'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
+                'it is possible that information could leak between requests'
+    }
+    implementation('org.apache.tomcat.embed:tomcat-embed-websocket:9.0.40') {
+        because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
+                'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
+                'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
+                'it is possible that information could leak between requests'
+    }
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     testCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok


### PR DESCRIPTION
### Change description ###

Upgraded httpclient and hibernate-core versions to fix CVE-2020-13956 and CVE-2020-25638

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
