### PR TITLE
fix: RDCC-3557 Upgraded springboot version to fix CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,9 +398,9 @@ dependencies {
     }
 
     testImplementation group: 'com.github.mifmif', name: 'generex', version: '1.0.2'
-    testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.14'
-    testImplementation group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.14'
-    testImplementation group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.14'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.15'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.15'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.15'
     testCompile 'com.github.hmcts:fortify-client:1.2.0:all'
 
     contractTestImplementation(group: 'au.com.dius', name:'pact-jvm-consumer-junit5_2.12', version: versions.pact_version) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "info.solidsoft.pitest" version '1.5.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.sonarqube' version '3.1.1'
-    id 'org.springframework.boot' version '2.4.9'
+    id 'org.springframework.boot' version '2.4.12'
     id "org.flywaydb.flyway" version "7.0.2"
     id 'au.com.dius.pact' version '4.1.7'// do not change, otherwise serenity report fails
 }
@@ -35,7 +35,7 @@ def versions = [
         reformS2sClient    : '4.0.0',
         serenity           : '2.0.76',
         sonarPitest        : '0.5',
-        springBoot         : '2.4.9',
+        springBoot         : '2.4.12',
         springHystrix      : '2.2.8.RELEASE',
         springfoxSwagger   : '2.9.2',
         pact_version       : '3.5.24',


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-3557


### Change description ###
Fixed CVE-2021-22096 by upgrading springboot version to 2.4.12


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
