### PR TITLE
RDCC-3799: upgrading log4j to '2.16.0'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ def versions = [
         springfoxSwagger   : '2.9.2',
         pact_version       : '3.5.24',
         launchDarklySdk    : "5.2.2",
-        log4j              : '2.15.0'
+        log4j              : '2.16.0'
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.userprofileapi.Application'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-3799

### Change description ###

upgrading log4j to '2.16.0'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
