### PR TITLE
RDCC-4633: Upgrading `launchDarklySdk` to `5.8.1` (CVE-2022-25647 Fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def versions = [
         springHystrix      : '2.2.8.RELEASE',
         springfoxSwagger   : '2.9.2',
         pact_version       : '3.5.24',
-        launchDarklySdk    : "5.2.2",
+        launchDarklySdk    : "5.8.1",
         log4j              : '2.17.1'
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-4633

### Change description ###

Upgrading `launchDarklySdk` to `5.8.1` _(`CVE-2022-25647` Fix)_

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
