### PR TITLE
CVE fix: Bumped spring dependencies version to 5.3.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ def versions = [
         springfoxSwagger   : '2.9.2',
         pact_version       : '3.5.24',
         launchDarklySdk    : "5.8.1",
-        log4j              : '2.17.1'
+        log4j              : '2.17.1',
+        springVersion      : '5.3.20'
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.userprofileapi.Application'
@@ -319,23 +320,23 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
 
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.2'
-    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.19'
 
     implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.6.1'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
     implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
-    implementation group: 'org.springframework', name: 'spring-aop', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-aspects', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-context', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-context-support', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-expression', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-jcl', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-orm', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-tx', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-web', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-webmvc', version: '5.3.18'
+    implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-aop', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-aspects', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-context', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-context-support', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-expression', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-jcl', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-orm', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-tx', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-web', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-webmvc', version: versions.springVersion
 
     implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.5'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-4707


### Change description ###
Bumped spring dependencies version to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
