### PR TITLE
RDCC-4945 Delete dependabot yaml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-4945

### Change description ###

Deleted dependabot yaml file as Renovate changes are already in place to upgrade the dependencies automatically

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```