### PR TITLE
RDCC-5261: Upgrading `postgresql` to `42.4.1`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,7 +369,7 @@ dependencies {
 
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.2'
 
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
     implementation group: 'javax.el', name: 'javax.el-api', version: '3.0.1-b06'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5261

### Change description ###

Upgrading `postgresql` to `42.4.1` to fix `CVE-2022-31197`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
