### PR TITLE
RDCC-5392: adding suppression for `CVE-2022-25857`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,7 +377,7 @@ dependencies {
 
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
 
-    implementation group:"org.yaml", name: "snakeyaml", version:"1.30"
+    implementation group:"org.yaml", name: "snakeyaml", version:"1.31"
     implementation (group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0') {
         exclude group: "com.sun.xml.bind", module: "jaxb-osgi"
         exclude group: "org.apache.sling"

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,4 +19,9 @@
      ]]></notes>
         <cve>CVE-2022-34305</cve>
     </suppress>
+    <suppress>
+        <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2022-25857</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5392

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
