### PR TITLE
RDCC-5534: Upgrading `launchdarkly-java-server-sdk` & `snakeyaml`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def versions = [
         springHystrix      : '2.2.8.RELEASE',
         springfoxSwagger   : '2.9.2',
         pact_version       : '3.5.24',
-        launchDarklySdk    : "5.10.0",
+        launchDarklySdk    : "5.10.2",
         log4j              : '2.17.1',
         springVersion      : '5.3.20',
         jackson            : '2.13.3',
@@ -377,7 +377,7 @@ dependencies {
 
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
 
-    implementation group:"org.yaml", name: "snakeyaml", version:"1.31"
+    implementation group:"org.yaml", name: "snakeyaml", version:"1.33"
     implementation (group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0') {
         exclude group: "com.sun.xml.bind", module: "jaxb-osgi"
         exclude group: "org.apache.sling"

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,12 +19,4 @@
      ]]></notes>
         <cve>CVE-2022-34305</cve>
     </suppress>
-    <suppress>
-        <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2022-25857</cve>
-        <cve>CVE-2022-38749</cve>
-        <cve>CVE-2022-38750</cve>
-        <cve>CVE-2022-38751</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5534

### Change description ###

Upgrading `launchdarkly-java-server-sdk` & `snakeyaml` to fix CVE-2022-38752

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
