### PR TITLE
Addresses CVE-2023-20863

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def versions = [
         pact_version       : '4.1.7',
         launchDarklySdk    : '5.10.7',
         log4j              : '2.17.1',
-        springVersion      : '5.3.26',
+        springVersion      : '5.3.27',
         jackson            : '2.14.0-rc1',
         feign              : '3.8.0',
         testContainer_postgresql: '1.17.6'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-264

### Change description ###

Addresses nightly build failure due to CVE-2023-20863

Mitigated in spring 5.3.27
https://spring.io/security/cve-2023-20863



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
