### PR TITLE
Addresses CVE-2023-42794, CVE-2023-42795 and CVE-2023-45648

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -533,7 +533,7 @@ dependencyManagement {
         // CVE-2021-33037
         // CVE-2021-42340
         // CVE-2023-28709
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.80') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.81') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/charts/rd-user-profile-api/Chart.yaml
+++ b/charts/rd-user-profile-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: Reference Data Team
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 5.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/charts/rd-user-profile-api/Chart.yaml
+++ b/charts/rd-user-profile-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for rd-user-profile-api
 name: rd-user-profile-api
 home: https://github.com/hmcts/rd-user-profile-api
-version: 0.0.28
+version: 0.0.29
 maintainers:
   - name: Reference Data Team
 dependencies:


### PR DESCRIPTION
### Change description ###

Addresses nightly build failure due to [CVE-2023-42794](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42794), [CVE-2023-42795](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42795) and
[CVE-2023-45648](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-45648)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
