### PR TITLE
Master build failure fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,9 +400,11 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.11'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.11'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.9'
+    implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.6'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
+    implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.32'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.8'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.8'
 
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testContainer_postgresql
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: versions.testContainer_postgresql

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def versions = [
         junitPlatform      : '1.9.2',
         lombok             : '1.18.22',
         pitest             : '1.7.4',
-        reformLogging      : '5.1.9',
+        reformLogging      : '6.0.1',
         serenity           : '2.0.76',
         springBoot         : '2.7.14',
         springHystrix      : '2.2.8.RELEASE',

--- a/build.gradle
+++ b/build.gradle
@@ -400,8 +400,8 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.11'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.11'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.11'
 
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testContainer_postgresql
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: versions.testContainer_postgresql

--- a/build.gradle
+++ b/build.gradle
@@ -402,6 +402,7 @@ dependencies {
 
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.11'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.11'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.9'
 
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testContainer_postgresql
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: versions.testContainer_postgresql


### PR DESCRIPTION
### Change description ###

Update to java-logging 6.0.1 (any version below 6.0.1 is deprecated and causes master build failure)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
