### PR TITLE
DTSRD-2803

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ def versions = [
         feign              : '3.8.0',
         testContainer_postgresql: '1.17.6',
         bouncycastle       : '1.77',
-        logback            : '1.2.13'
+        logback            : '1.2.13',
+        okio               : '3.4.0'
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.userprofileapi.Application'
@@ -605,6 +606,11 @@ configurations.all {
                 || details.requested.name == 'bcprov-jdk18on')
         ){
             details.useVersion versions.bouncycastle
+        }
+
+        if (details.requested.group == 'com.squareup.okio'
+            && details.requested.name == 'okio') {
+            details.useVersion versions.okio
         }
     }
 }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,7 +11,4 @@ file name: launchdarkly-java-server-sdk-5.10.7.jar (shaded: org.yaml:snakeyaml:1
         <notes>Suppressing disputed CVE: https://github.com/FasterXML/jackson-databind/issues/3972</notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
-    <suppress>
-        <cve>CVE-2023-3635</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSRD-2803

### Change description ###

- updated okio transitive dependency to 3.4.0
- removed suppression for CVE-2023-3635

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
