### PR TITLE
DTSRD-3580 Jenkins Test Reports to Publish on Failure

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -88,7 +88,7 @@ withPipeline(type, product, component) {
         env.TEST_URL = "http://rd-user-profile-api-aat.aat.platform.hmcts.net"
     }
 
-    afterSuccess('sonarscan') {
+    afterAlways('sonarscan') {
 
         publishHTML target: [
             allowMissing         : true,
@@ -109,7 +109,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('smoketest:preview') {
+    afterAlways('smoketest:preview') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -120,7 +120,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('smoketest:aat') {
+    afterAlways('smoketest:aat') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -131,7 +131,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('functionalTest:aat') {
+    afterAlways('functionalTest:aat') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -143,7 +143,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('functionalTest:preview') {
+    afterAlways('functionalTest:preview') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -155,7 +155,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('pact-provider-verification') {
+    afterAlways('pact-provider-verification') {
         publishHTML target: [
              allowMissing         : true,
              alwaysLinkToLastBuild: true,

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -72,7 +72,7 @@ withNightlyPipeline(type, product, component) {
     enableSecurityScan()
     enableFortifyScan()
 
-    afterSuccess('fullFunctionalTest') {
+    afterAlways('fullFunctionalTest') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
         publishHTML target: [
@@ -92,11 +92,11 @@ withNightlyPipeline(type, product, component) {
         print "done delete script for nightly"
     }
 
-    afterSuccess('fortify-scan') {
+    afterAlways('fortify-scan') {
        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
      }
 
-    afterSuccess('mutationTest') {
+    afterAlways('mutationTest') {
         publishHTML target: [
                 allowMissing         : true,
                 alwaysLinkToLastBuild: true,


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSRD-3580

### Change description
Jenkins Test Reports to Publish on Failure - afterSuccess() replaced with afterAlways() for all reports in Jenkinsfile_CNP and nightly

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
